### PR TITLE
06 - Synchronized and sorted list - fix race condition, improved toString method

### DIFF
--- a/06 - Synchronized and sorted list/06 - Synchronized and sorted list.vcxproj
+++ b/06 - Synchronized and sorted list/06 - Synchronized and sorted list.vcxproj
@@ -95,6 +95,7 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -110,6 +111,7 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -141,6 +143,7 @@
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <LanguageStandard>stdcpp20</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/06 - Synchronized and sorted list/source/BubbleSort.cpp
+++ b/06 - Synchronized and sorted list/source/BubbleSort.cpp
@@ -1,11 +1,11 @@
 #include "BubbleSort.h"
 
-#include <cassert>
-
-void BubbleSort::sort(Data* front, /* unused */ Data* end) const
+void BubbleSort::sort(Data* front) const
 {
-	assert(front != nullptr && "The `front` pointer is NULL in BubbleSort::sort");
-	assert(end != nullptr && "The `end` pointer is NULL in BubbleSort::sort");
+	if (front == nullptr)
+	{
+		return;
+	}
 
 	front->lock();
 	Data* firstPointer = front;
@@ -69,7 +69,7 @@ void BubbleSort::setToTheNextPointer(Data** pointer, const bool unlockPointer)
 		return;
 	}
 
-	const Data* pointerToUnlock = *pointer;
+	Data* pointerToUnlock = *pointer;
 	(*pointer) = (*pointer)->getNext();
 	pointerToUnlock->unlock();
 }

--- a/06 - Synchronized and sorted list/source/BubbleSort.h
+++ b/06 - Synchronized and sorted list/source/BubbleSort.h
@@ -12,9 +12,10 @@ public:
 	BubbleSort& operator=(BubbleSort&&) = delete;
 
 	virtual ~BubbleSort() override = default;
-	virtual void sort(Data* front, Data* end) const override;
+	virtual void sort(Data* front) const override;
+
 private:
-	static void swap(Data* first, Data* second);
+	static void swap(Data* firstPointer, Data* secondPointer);
 	static void setToTheNextPointer(Data** pointer, const bool unlockPointer);
 };
 

--- a/06 - Synchronized and sorted list/source/Data.cpp
+++ b/06 - Synchronized and sorted list/source/Data.cpp
@@ -2,8 +2,7 @@
 
 Data::Data(std::string message)
 	:
-	message(std::move(message)),
-	dataMutex(new std::mutex)
+	message(std::move(message))
 {
 }
 
@@ -30,14 +29,19 @@ void Data::setMessage(const std::string& newMessage)
 	message = newMessage;
 }
 
-void Data::lock() const
+std::unique_lock<std::mutex> Data::getUniqueLock()
 {
-	dataMutex->lock();
+	return std::unique_lock(dataMutex);
 }
 
-void Data::unlock() const
+void Data::lock()
 {
-	dataMutex->unlock();
+	dataMutex.lock();
+}
+
+void Data::unlock()
+{
+	dataMutex.unlock();
 }
 
 bool operator>(const Data& data1, const Data& data2)

--- a/06 - Synchronized and sorted list/source/Data.h
+++ b/06 - Synchronized and sorted list/source/Data.h
@@ -9,12 +9,13 @@ public:
 	void setNext(Data* data);
 	[[nodiscard]] const std::string& getMessage() const;
 	void setMessage(const std::string& newMessage);
-	void lock() const;
-	void unlock() const;
+	std::unique_lock<std::mutex> getUniqueLock();
+	void lock();
+	void unlock();
 private:
 	Data* next = nullptr;
 	std::string message;
-	std::shared_ptr<std::mutex> dataMutex;
+	std::mutex dataMutex;
 };
 
 bool operator> (const Data& data1, const Data& data2);

--- a/06 - Synchronized and sorted list/source/SortAlgorithm.h
+++ b/06 - Synchronized and sorted list/source/SortAlgorithm.h
@@ -12,6 +12,7 @@ public:
 	SortAlgorithm(SortAlgorithm&&) = delete;
 	virtual ~SortAlgorithm() = default;
 
-	virtual void sort(Data* front, Data * end) const = 0;
+	virtual void sort(Data* front) const = 0;
+
 };
 

--- a/06 - Synchronized and sorted list/source/Sorter.cpp
+++ b/06 - Synchronized and sorted list/source/Sorter.cpp
@@ -48,7 +48,7 @@ bool Sorter::sort(const SortAlgorithm& sortAlgorithm)
 		return false;
 	}
 
-	sortAlgorithm.sort(synchronizedList->getFront(), synchronizedList->getEnd());
+	sortAlgorithm.sort(synchronizedList->getFront());
 	printf("The synchronizedList has been sorted\n");
 	return true;
 }

--- a/06 - Synchronized and sorted list/source/SynchronizedList.h
+++ b/06 - Synchronized and sorted list/source/SynchronizedList.h
@@ -10,7 +10,7 @@
 class SynchronizedList final : public Subject
 {
 public:
-	SynchronizedList() = default;
+	SynchronizedList();
 	SynchronizedList(const SynchronizedList&) = delete;
 	SynchronizedList(SynchronizedList&&) = delete;
 	SynchronizedList& operator=(const SynchronizedList&) = delete;
@@ -24,15 +24,13 @@ public:
 	virtual void notify() override;
 
 	[[nodiscard]] Data* getFront() const;
-	[[nodiscard]] Data* getEnd() const;
 	[[nodiscard]] std::string toString() const;
 private:
 	friend std::ostream& operator <<(std::ostream& os, const SynchronizedList& synchronizedList);
 
-	Data* front = nullptr;
-	Data* end = nullptr;
-
+	std::shared_ptr<Data> sentinel;
 	std::list<Observer*> observers;
-	std::mutex writeMutex;
+
+	std::mutex observersMutex;
 };
 


### PR DESCRIPTION

-  Array of observers is not synchronized.
-  inputThread may not finish constructor yet, but at the same time thread is already running and running, and takes an intu - solved via semaphore - THIS IS NOT A BIG deal at the moment.
-  getFront, getEnd are not synchronized
-  writeMutex blocks writing at all. You need to use Data mutexes. You need it to synchronize pushBack at the beginning of front. writeMutex → frontMutex.
-   print is not protected, you need to protect it, and block multiple mutexes. It can produce undefined behavior.
-   sort no check for null front

